### PR TITLE
fixed stime and extra print

### DIFF
--- a/Userland/SampleCodeModule/define.h
+++ b/Userland/SampleCodeModule/define.h
@@ -30,7 +30,7 @@
 #define GET_CPU_VENDOR_COMMAND	"cpuid"
 #define PLAY_TEST_COMMAND "playtest"
 #define KEYBOARD_SOUND_COMMAND "rkeyboard"
-#define CHOSE_MUSIC_COMMAND "chosemusic"
+#define CHOSE_MUSIC_COMMAND "choosemusic"
 
 #define MUSIC_ZERO 0
 #define MUSIC_ONE 1

--- a/Userland/SampleCodeModule/define.h~
+++ b/Userland/SampleCodeModule/define.h~
@@ -14,10 +14,11 @@
 #define COMMAND_LINE_SIZE	77
 #define GET_DATE			0
 #define SET_DATE			1
-#define SET_SCREENSAVER			2
-#define GET_CPU_VENDOR			3
+#define SET_SCREENSAVER		2
+#define GET_CPU_VENDOR		3
 #define PLAY_TEST 			4
-#define RINGING_KEYBOARD		5
+#define RINGING_KEYBOARD	5
+#define CHOSE_MUSIC 		6
 
 #define STDIN	0
 #define STDOUT	1
@@ -29,8 +30,13 @@
 #define GET_CPU_VENDOR_COMMAND	"cpuid"
 #define PLAY_TEST_COMMAND "playtest"
 #define KEYBOARD_SOUND_COMMAND "rkeyboard"
+#define CHOSE_MUSIC_COMMAND "choosemusic"
 
-#define ASCII_DELETE	127
+#define MUSIC_ZERO 0
+#define MUSIC_ONE 1
+#define MUSIC_TWO 2
+#define MUSIC_THREE 3
+#define MUSIC_FOUR 4
 
 typedef struct date {
 	uint8_t year;

--- a/Userland/SampleCodeModule/shell.c
+++ b/Userland/SampleCodeModule/shell.c
@@ -193,8 +193,8 @@ static void help()
 			printf("Plays a different sound for each key until you press enter\n");
 			break;
 		case CHOSE_MUSIC:
-			printf("CHOSE MUSIC\n");
-			printf("Command: chosemusic\n");
+			printf("CHOOSE MUSIC\n");
+			printf("Command: choosemusic\n");
 			printf("Choose one of our musics and play\n");
 			break;
 		default:
@@ -217,7 +217,6 @@ static void setTime()
 		}
 	} while ( year <= 0 || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59);
 	
-	printf("day: %d\n", day);
 	current_date.hour = hour;
 	current_date.minute = minute;
 	current_date.second = second;
@@ -236,8 +235,8 @@ void printStruct ( date * current_date ){
 	printf("Seconds: %d\n", current_date->second);
 	printf("Minutes: %d\n", current_date->minute);
 	printf("Hours: %d\n", current_date->hour);
-	printf("Day: \n", current_date->day);
-	printf("Month: \n", current_date->month);
+	printf("Day: %d\n", current_date->day);
+	printf("Month: %d\n", current_date->month);
 	printf("Year: %d\n", current_date->year);
 }
 

--- a/Userland/SampleCodeModule/shell.c
+++ b/Userland/SampleCodeModule/shell.c
@@ -212,10 +212,10 @@ static void setTime()
 	printf("Enter date in this format: YY MM DD HH MM SS\n");
 	do {
 		scanf("%d %d %d %d %d %d", &year, &month, &day, &hour, &minute, &second);
-		if (year <= 0  || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 50 || second < 0 || second > 59){
+		if (year <= 0  || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59){
 			printf("Invalid Format\n");
 		}
-	} while ( year <= 0 || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 50 || second < 0 || second > 59);
+	} while ( year <= 0 || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59);
 	
 	printf("day: %d\n", day);
 	current_date.hour = hour;
@@ -279,7 +279,6 @@ static void playTest()
 	for(i=1;i<15;i++) {
 		execSysCall(SYS_SOUND, 500, 590-10*i, 0); // Time - Freq	
 	}
-	printf("playing sound\n");
 }
 
 static void ringingKeyboard()
@@ -293,7 +292,6 @@ static void ringingKeyboard()
 				putChar(c);
 				i--;
 			}
-			printf("%d\n", c*100);
 			execSysCall(SYS_SOUND, 500, 440 + (c*100), 0);
 		}else{
 			putChar(c);

--- a/Userland/SampleCodeModule/shell.c~
+++ b/Userland/SampleCodeModule/shell.c~
@@ -153,7 +153,7 @@ static void help()
 	printf("3 - GET CPU VENDOR\n");
 	printf("4 - TEST SOUND\n");
 	printf("5 - RING KEYBOARD\n");
-	printf("6 - CHOSE MUSIC\n");
+	printf("6 - CHOOSE MUSIC\n");
 
 	if (scanf("%d", &opt) == 0 || opt > 6) {
 		printf("Invalid option\n");
@@ -193,9 +193,9 @@ static void help()
 			printf("Plays a different sound for each key until you press enter\n");
 			break;
 		case CHOSE_MUSIC:
-			printf("CHOSE MUSIC\n");
+			printf("CHOOSE MUSIC\n");
 			printf("Command: chosemusic\n");
-			printf("Chose one of our musics and play\n");
+			printf("Choose one of our musics and play\n");
 			break;
 		default:
 			printf("Invalid command.\n");
@@ -212,12 +212,11 @@ static void setTime()
 	printf("Enter date in this format: YY MM DD HH MM SS\n");
 	do {
 		scanf("%d %d %d %d %d %d", &year, &month, &day, &hour, &minute, &second);
-		if (year <= 0  || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 50 || second < 0 || second > 59){
+		if (year <= 0  || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59){
 			printf("Invalid Format\n");
 		}
-	} while ( year <= 0 || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 50 || second < 0 || second > 59);
+	} while ( year <= 0 || year > 99 || month <= 0 || day <= 0 || day > 31 || month > 12 || hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59);
 	
-	printf("day: %d\n", day);
 	current_date.hour = hour;
 	current_date.minute = minute;
 	current_date.second = second;
@@ -236,8 +235,8 @@ void printStruct ( date * current_date ){
 	printf("Seconds: %d\n", current_date->second);
 	printf("Minutes: %d\n", current_date->minute);
 	printf("Hours: %d\n", current_date->hour);
-	printf("Day: \n", current_date->day);
-	printf("Month: \n", current_date->month);
+	printf("Day: %d\n", current_date->day);
+	printf("Month: %d\n", current_date->month);
 	printf("Year: %d\n", current_date->year);
 }
 
@@ -279,7 +278,6 @@ static void playTest()
 	for(i=1;i<15;i++) {
 		execSysCall(SYS_SOUND, 500, 590-10*i, 0); // Time - Freq	
 	}
-	printf("playing sound\n");
 }
 
 static void ringingKeyboard()
@@ -293,7 +291,6 @@ static void ringingKeyboard()
 				putChar(c);
 				i--;
 			}
-			printf("%d\n", c*100);
 			execSysCall(SYS_SOUND, 500, 440 + (c*100), 0);
 		}else{
 			putChar(c);


### PR DESCRIPTION
## Summary

Fixed the stime function. It should work correctly now.
Erased some extra prinfts on function rkeyboard
## Test Plan

Execute stime and try changing the date and time. Test on limits specially (eg: hour 0, day 31, etc...)
Execute rkeyboard, no extra prints should be displayed
